### PR TITLE
obs: LGTM compose + app compose

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -68,7 +68,7 @@ docker compose -f deploy/compose/obs.yaml up -d
 Doporučené env proměnné:
 
 - `SMART_ADDRESS_OTEL_ENABLED` (výchozí: `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (výchozí: `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (výchozí: `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (výchozí: `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (volitelné)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (výchozí: `1` v dev, `0.05` v production)

--- a/README.cs.md
+++ b/README.cs.md
@@ -59,10 +59,10 @@ curl "http://localhost:8787/metrics"
 
 Smart Address posílá jeden wide event na request a trace přes Effect + OpenTelemetry.
 
-Lokální OTEL backend:
+Lokální OTEL backend (Grafana + Tempo + Loki + Prometheus + Pyroscope):
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 ```
 
 Doporučené env proměnné:
@@ -105,14 +105,14 @@ Tip na tagování (doporučeno pro produkci):
 docker build -t smart-address-service:$(git rev-parse --short HEAD) .
 ```
 
-Spuštění přes Docker Compose:
+Spuštění přes Docker Compose (jen služba):
 
 ```bash
 NOMINATIM_USER_AGENT="your-app-name" \
 NOMINATIM_EMAIL="you@example.com" \
 RADAR_API_KEY="your-radar-api-key" \
 HERE_API_KEY="your-here-api-key" \
-docker compose up -d
+docker compose -f deploy/compose/app.yaml up -d
 ```
 
 Tip: `docker compose` načítá `.env` v kořeni repa, takže můžete nastavit
@@ -123,6 +123,16 @@ Persistování SQLite DB:
 - Compose mountuje volume `smart-address-data` do `/app/data`.
 - Výchozí cesta DB je `data/smart-address.db` (relativně k `/app`).
 - Přepište přes `SMART_ADDRESS_DB_PATH` (např. `/app/data/custom.db`).
+
+Plná lokální observabilita (služba + LGTM):
+
+```bash
+NOMINATIM_USER_AGENT="your-app-name" \
+NOMINATIM_EMAIL="you@example.com" \
+RADAR_API_KEY="your-radar-api-key" \
+HERE_API_KEY="your-here-api-key" \
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
+```
 
 Doporučené env proměnné (zásady Nominatim):
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ curl "http://localhost:8787/metrics"
 
 Smart Address emits one wide event per request and traces via Effect + OpenTelemetry.
 
-Run a local OTEL backend:
+Run a local OTEL backend (Grafana + Tempo + Loki + Prometheus + Pyroscope):
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 ```
 
 Recommended env vars:
@@ -105,14 +105,14 @@ Tagging tip (recommended for production):
 docker build -t smart-address-service:$(git rev-parse --short HEAD) .
 ```
 
-Run with Docker Compose:
+Run with Docker Compose (service only):
 
 ```bash
 NOMINATIM_USER_AGENT="your-app-name" \
 NOMINATIM_EMAIL="you@example.com" \
 RADAR_API_KEY="your-radar-api-key" \
 HERE_API_KEY="your-here-api-key" \
-docker compose up -d
+docker compose -f deploy/compose/app.yaml up -d
 ```
 
 Tip: `docker compose` reads `.env` in the repo root, so you can set
@@ -123,6 +123,16 @@ Persist the SQLite DB:
 - Compose mounts the `smart-address-data` volume to `/app/data`.
 - The default DB path is `data/smart-address.db` (relative to `/app`).
 - Override with `SMART_ADDRESS_DB_PATH` (for example `/app/data/custom.db`).
+
+Run full local observability (service + LGTM):
+
+```bash
+NOMINATIM_USER_AGENT="your-app-name" \
+NOMINATIM_EMAIL="you@example.com" \
+RADAR_API_KEY="your-radar-api-key" \
+HERE_API_KEY="your-here-api-key" \
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
+```
 
 Recommended env vars (Nominatim usage policy):
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker compose -f deploy/compose/obs.yaml up -d
 Recommended env vars:
 
 - `SMART_ADDRESS_OTEL_ENABLED` (default: `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (default: `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (optional)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` in dev, `0.05` in production)

--- a/apps/docs/content/cs/explanation/observability.md
+++ b/apps/docs/content/cs/explanation/observability.md
@@ -20,7 +20,7 @@ docker compose -f deploy/compose/obs.yaml up -d
 Proměnné prostředí pro observabilitu:
 
 - `SMART_ADDRESS_OTEL_ENABLED` (default: `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (default: `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (volitelné)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` v dev, `0.05` v production)
@@ -32,7 +32,7 @@ Copy-paste příklad (lokální tracing):
 docker compose -f deploy/compose/obs.yaml up -d
 
 SMART_ADDRESS_OTEL_ENABLED=true \
-OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces" \
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
 OTEL_SERVICE_NAME="smart-address-service" \
 SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE=1 \
 pnpm --filter @smart-address/service-bun dev

--- a/apps/docs/content/cs/explanation/observability.md
+++ b/apps/docs/content/cs/explanation/observability.md
@@ -6,10 +6,11 @@ Vysvětlit, jak Smart Address posílá jeden wide event na request a jak generuj
 
 ## Předpoklady
 
+- Docker + Docker Compose.
 - (Volitelné) Lokální OpenTelemetry backend pro prohlížení trace:
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 ```
 
 - Spusťte službu s OTEL zapnutým (viz Vstupy).
@@ -28,13 +29,19 @@ Proměnné prostředí pro observabilitu:
 Copy-paste příklad (lokální tracing):
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 
 SMART_ADDRESS_OTEL_ENABLED=true \
 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces" \
 OTEL_SERVICE_NAME="smart-address-service" \
 SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE=1 \
 pnpm --filter @smart-address/service-bun dev
+```
+
+Spuštění služby a LGTM dohromady (Docker):
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 ```
 
 ## Výstup

--- a/apps/docs/content/en/explanation/observability.md
+++ b/apps/docs/content/en/explanation/observability.md
@@ -20,7 +20,7 @@ docker compose -f deploy/compose/obs.yaml up -d
 Environment variables that control observability:
 
 - `SMART_ADDRESS_OTEL_ENABLED` (default: `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (default: `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (default: `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (optional)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` in dev, `0.05` in production)
@@ -32,7 +32,7 @@ Copy-paste example (local tracing):
 docker compose -f deploy/compose/obs.yaml up -d
 
 SMART_ADDRESS_OTEL_ENABLED=true \
-OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces" \
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" \
 OTEL_SERVICE_NAME="smart-address-service" \
 SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE=1 \
 pnpm --filter @smart-address/service-bun dev

--- a/apps/docs/content/en/explanation/observability.md
+++ b/apps/docs/content/en/explanation/observability.md
@@ -6,10 +6,11 @@ Explain how Smart Address captures one wide event per request and emits traces v
 
 ## Prerequisites
 
+- Docker + Docker Compose.
 - (Optional) Local OpenTelemetry backend for viewing traces:
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 ```
 
 - Run the service with OTEL enabled (see Inputs).
@@ -28,13 +29,19 @@ Environment variables that control observability:
 Copy-paste example (local tracing):
 
 ```bash
-docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -it docker.io/grafana/otel-lgtm
+docker compose -f deploy/compose/obs.yaml up -d
 
 SMART_ADDRESS_OTEL_ENABLED=true \
 OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces" \
 OTEL_SERVICE_NAME="smart-address-service" \
 SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE=1 \
 pnpm --filter @smart-address/service-bun dev
+```
+
+Run the service and LGTM together (Docker):
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 ```
 
 ## Output

--- a/apps/service-bun/src/config.ts
+++ b/apps/service-bun/src/config.ts
@@ -134,6 +134,8 @@ const trimmedOrDefault = (value: string, fallback: string): string => {
   return trimmed.length > 0 ? trimmed : fallback;
 };
 
+const otelEndpointTrimTrailingSlashes = /\/+$/;
+
 const normalizeOtelEndpoint = (value: string): string => {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
@@ -142,7 +144,7 @@ const normalizeOtelEndpoint = (value: string): string => {
   if (trimmed.endsWith("/v1/traces")) {
     return trimmed;
   }
-  return `${trimmed.replace(/\/+$/, "")}/v1/traces`;
+  return `${trimmed.replace(otelEndpointTrimTrailingSlashes, "")}/v1/traces`;
 };
 
 const defaultSampleRate = (): number => {

--- a/apps/service-bun/src/config.ts
+++ b/apps/service-bun/src/config.ts
@@ -83,7 +83,7 @@ const rawConfig = Config.all({
     Config.withDefault(true)
   ),
   otelEndpoint: Config.string("OTEL_EXPORTER_OTLP_ENDPOINT").pipe(
-    Config.withDefault("http://localhost:4318/v1/traces")
+    Config.withDefault("http://localhost:4318")
   ),
   otelServiceName: Config.string("OTEL_SERVICE_NAME").pipe(
     Config.withDefault("smart-address-service")
@@ -132,6 +132,17 @@ const buildProviderBaseConfig = (options: {
 const trimmedOrDefault = (value: string, fallback: string): string => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : fallback;
+};
+
+const normalizeOtelEndpoint = (value: string): string => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return "http://localhost:4318/v1/traces";
+  }
+  if (trimmed.endsWith("/v1/traces")) {
+    return trimmed;
+  }
+  return `${trimmed.replace(/\/+$/, "")}/v1/traces`;
 };
 
 const defaultSampleRate = (): number => {
@@ -334,7 +345,7 @@ export const addressServiceConfig = rawConfig.pipe(
       sqlite: buildSqliteConfig(trimmedOptional(raw.sqlitePath)),
       observability: {
         otelEnabled: raw.otelEnabled,
-        otelEndpoint: raw.otelEndpoint.trim(),
+        otelEndpoint: normalizeOtelEndpoint(raw.otelEndpoint),
         otelServiceName: trimmedOrDefault(
           raw.otelServiceName,
           "smart-address-service"

--- a/deploy/compose/app.yaml
+++ b/deploy/compose/app.yaml
@@ -7,9 +7,7 @@ services:
       - "8787:8787"
     environment:
       SMART_ADDRESS_OTEL_ENABLED: "true"
-      SMART_ADDRESS_OBSERVABILITY_OTEL_ENABLED: "true"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://lgtm:4318/v1/traces"
-      SMART_ADDRESS_OBSERVABILITY_OTEL_ENDPOINT: "http://lgtm:4318/v1/traces"
       OTEL_SERVICE_NAME: "smart-address-service"
       NOMINATIM_USER_AGENT: "${NOMINATIM_USER_AGENT:-smart-address-service}"
       NOMINATIM_EMAIL: "${NOMINATIM_EMAIL:-}"

--- a/deploy/compose/app.yaml
+++ b/deploy/compose/app.yaml
@@ -1,0 +1,49 @@
+services:
+  smart-address:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8787:8787"
+    environment:
+      SMART_ADDRESS_OTEL_ENABLED: "true"
+      SMART_ADDRESS_OBSERVABILITY_OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://lgtm:4318/v1/traces"
+      SMART_ADDRESS_OBSERVABILITY_OTEL_ENDPOINT: "http://lgtm:4318/v1/traces"
+      OTEL_SERVICE_NAME: "smart-address-service"
+      NOMINATIM_USER_AGENT: "${NOMINATIM_USER_AGENT:-smart-address-service}"
+      NOMINATIM_EMAIL: "${NOMINATIM_EMAIL:-}"
+      # Optional overrides:
+      # NOMINATIM_BASE_URL: "https://nominatim.openstreetmap.org"
+      # NOMINATIM_REFERER: "https://your-app.example"
+      # SMART_ADDRESS_DB_PATH: "/app/data/smart-address.db"
+      RADAR_API_KEY: "${RADAR_API_KEY:-}"
+      RADAR_AUTOCOMPLETE_BASE_URL: "${RADAR_AUTOCOMPLETE_BASE_URL:-}"
+      RADAR_AUTOCOMPLETE_DEFAULT_LIMIT: "${RADAR_AUTOCOMPLETE_DEFAULT_LIMIT:-}"
+      RADAR_AUTOCOMPLETE_LAYERS: "${RADAR_AUTOCOMPLETE_LAYERS:-}"
+      RADAR_AUTOCOMPLETE_NEAR: "${RADAR_AUTOCOMPLETE_NEAR:-}"
+      RADAR_AUTOCOMPLETE_COUNTRY_CODE: "${RADAR_AUTOCOMPLETE_COUNTRY_CODE:-}"
+      RADAR_AUTOCOMPLETE_RATE_LIMIT_MS: "${RADAR_AUTOCOMPLETE_RATE_LIMIT_MS:-}"
+      HERE_API_KEY: "${HERE_API_KEY:-}"
+      HERE_DISCOVER_BASE_URL: "${HERE_DISCOVER_BASE_URL:-}"
+      HERE_DISCOVER_DEFAULT_LIMIT: "${HERE_DISCOVER_DEFAULT_LIMIT:-}"
+      HERE_DISCOVER_LANGUAGE: "${HERE_DISCOVER_LANGUAGE:-}"
+      HERE_DISCOVER_IN_AREA: "${HERE_DISCOVER_IN_AREA:-}"
+      HERE_DISCOVER_AT: "${HERE_DISCOVER_AT:-}"
+      HERE_DEFAULT_LAT: "${HERE_DEFAULT_LAT:-}"
+      HERE_DEFAULT_LNG: "${HERE_DEFAULT_LNG:-}"
+      HERE_DISCOVER_RATE_LIMIT_MS: "${HERE_DISCOVER_RATE_LIMIT_MS:-}"
+    volumes:
+      - smart-address-data:/app/data
+    restart: unless-stopped
+    depends_on:
+      - lgtm
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+volumes:
+  smart-address-data:

--- a/deploy/compose/app.yaml
+++ b/deploy/compose/app.yaml
@@ -7,7 +7,7 @@ services:
       - "8787:8787"
     environment:
       SMART_ADDRESS_OTEL_ENABLED: "true"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://lgtm:4318/v1/traces"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://lgtm:4318"
       OTEL_SERVICE_NAME: "smart-address-service"
       NOMINATIM_USER_AGENT: "${NOMINATIM_USER_AGENT:-smart-address-service}"
       NOMINATIM_EMAIL: "${NOMINATIM_EMAIL:-}"
@@ -35,7 +35,8 @@ services:
       - smart-address-data:/app/data
     restart: unless-stopped
     depends_on:
-      - lgtm
+      lgtm:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8787/health"]
       interval: 30s

--- a/deploy/compose/obs.yaml
+++ b/deploy/compose/obs.yaml
@@ -1,0 +1,16 @@
+services:
+  lgtm:
+    image: grafana/otel-lgtm
+    ports:
+      - "3000:3000"
+      - "4317:4317"
+      - "4318:4318"
+      - "4040:4040"
+      - "9090:9090"
+      - "9009:9009"
+    volumes:
+      - lgtm-data:/data
+    restart: unless-stopped
+
+volumes:
+  lgtm-data:

--- a/deploy/compose/obs.yaml
+++ b/deploy/compose/obs.yaml
@@ -16,6 +16,12 @@ services:
         limits:
           cpus: "1.0"
           memory: 1g
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 5
 
 volumes:
   lgtm-data:

--- a/deploy/compose/obs.yaml
+++ b/deploy/compose/obs.yaml
@@ -11,6 +11,11 @@ services:
     volumes:
       - lgtm-data:/data
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
 
 volumes:
   lgtm-data:

--- a/scripts/free-ports.sh
+++ b/scripts/free-ports.sh
@@ -6,6 +6,21 @@ cd "$ROOT_DIR"
 
 PORTS="${PORTS:-8787 3000}"
 
+usage() {
+  cat <<'EOF'
+Usage: PORTS="8787 3000" scripts/free-ports.sh
+
+Frees any processes listening on the ports listed in $PORTS (default: "8787 3000")
+by calling kill_port for each entry. If Docker is available, the script also
+runs "docker compose down" to stop local compose services.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
 kill_port() {
   local port="$1"
   local pids=""

--- a/scripts/free-ports.sh
+++ b/scripts/free-ports.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PORTS="${PORTS:-8787 3000}"
+
+kill_port() {
+  local port="$1"
+  local pids=""
+  if command -v lsof >/dev/null 2>&1; then
+    pids="$(lsof -tiTCP:"${port}" -sTCP:LISTEN || true)"
+  elif command -v ss >/dev/null 2>&1; then
+    pids="$(ss -ltnp "sport = :${port}" 2>/dev/null | awk 'NR>1 {print $NF}' | sed 's/pid=//;s/,.*//' | sort -u | tr '\n' ' ' || true)"
+  elif command -v netstat >/dev/null 2>&1; then
+    pids="$(netstat -anvp tcp 2>/dev/null | awk -v p=":${port}" '$4 ~ p && $6 == "LISTEN" {print $9}' | sort -u | tr '\n' ' ' || true)"
+  fi
+
+  if [[ -n "${pids}" ]]; then
+    echo "Killing processes on port ${port}: ${pids}"
+    kill ${pids} 2>/dev/null || true
+  fi
+}
+
+for port in ${PORTS}; do
+  kill_port "${port}"
+done
+
+if command -v docker >/dev/null 2>&1; then
+  docker compose down >/dev/null 2>&1 || true
+fi

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 SERVICE_PID=""
 COMPOSE_UP="0"
+COMPOSE_FILES=(-f deploy/compose/obs.yaml -f deploy/compose/app.yaml)
 
 if [[ -x "$ROOT_DIR/scripts/free-ports.sh" ]]; then
   "$ROOT_DIR/scripts/free-ports.sh"
@@ -17,7 +18,7 @@ cleanup() {
     wait "${SERVICE_PID}" 2>/dev/null || true
   fi
   if [[ "${COMPOSE_UP}" == "1" ]]; then
-    docker compose down
+    docker compose "${COMPOSE_FILES[@]}" down
   fi
 }
 
@@ -75,7 +76,7 @@ wait "${SERVICE_PID}" 2>/dev/null || true
 SERVICE_PID=""
 
 run docker build -t smart-address-service .
-run docker compose up -d
+run docker compose "${COMPOSE_FILES[@]}" up -d
 COMPOSE_UP="1"
 
 if ! wait_for_health; then
@@ -86,5 +87,5 @@ fi
 run curl -fsS "http://localhost:8787/health"
 run curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ"
 
-docker compose down
+docker compose "${COMPOSE_FILES[@]}" down
 COMPOSE_UP="0"

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -68,7 +68,24 @@ run curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ"
 run curl -fsS -X POST "http://localhost:8787/accept" \
   -H "content-type: application/json" \
   --data @- <<'JSON'
-{"text":"Prague","strategy":"reliable","resultIndex":0,"resultCount":5,"suggestion":{"id":"nominatim:123","label":"Prague, CZ","address":{"city":"Prague","countryCode":"CZ"},"source":{"provider":"nominatim","kind":"public"}}}
+{
+  "text": "Prague",
+  "strategy": "reliable",
+  "resultIndex": 0,
+  "resultCount": 5,
+  "suggestion": {
+    "id": "nominatim:123",
+    "label": "Prague, CZ",
+    "address": {
+      "city": "Prague",
+      "countryCode": "CZ"
+    },
+    "source": {
+      "provider": "nominatim",
+      "kind": "public"
+    }
+  }
+}
 JSON
 
 kill "${SERVICE_PID}" 2>/dev/null || true

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SERVICE_PID=""
+COMPOSE_UP="0"
+
+if [[ -x "$ROOT_DIR/scripts/free-ports.sh" ]]; then
+  "$ROOT_DIR/scripts/free-ports.sh"
+fi
+
+cleanup() {
+  if [[ -n "${SERVICE_PID}" ]]; then
+    kill "${SERVICE_PID}" 2>/dev/null || true
+    wait "${SERVICE_PID}" 2>/dev/null || true
+  fi
+  if [[ "${COMPOSE_UP}" == "1" ]]; then
+    docker compose down
+  fi
+}
+
+trap cleanup EXIT
+
+run() {
+  echo "==> $*"
+  "$@"
+}
+
+wait_for_health() {
+  local attempts=30
+  local i=1
+  while [[ "${i}" -le "${attempts}" ]]; do
+    if curl -fsS "http://localhost:8787/health" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+run pnpm install
+run pnpm check
+run pnpm typecheck
+run pnpm test
+run pnpm check:quality
+run pnpm check:publint
+run pnpm check:tree
+run pnpm build
+run pnpm --filter docs build
+run pnpm --filter landing test
+run pnpm --filter landing build
+run pnpm --filter @smart-address/sdk test
+
+run pnpm --filter @smart-address/service-bun start &
+SERVICE_PID=$!
+
+if ! wait_for_health; then
+  echo "Service failed to become healthy on http://localhost:8787/health"
+  exit 1
+fi
+
+run curl -fsS "http://localhost:8787/health"
+run curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ"
+run curl -fsS -X POST "http://localhost:8787/accept" \
+  -H "content-type: application/json" \
+  --data @- <<'JSON'
+{"text":"Prague","strategy":"reliable","resultIndex":0,"resultCount":5,"suggestion":{"id":"nominatim:123","label":"Prague, CZ","address":{"city":"Prague","countryCode":"CZ"},"source":{"provider":"nominatim","kind":"public"}}}
+JSON
+
+kill "${SERVICE_PID}" 2>/dev/null || true
+wait "${SERVICE_PID}" 2>/dev/null || true
+SERVICE_PID=""
+
+run docker build -t smart-address-service .
+run docker compose up -d
+COMPOSE_UP="1"
+
+if ! wait_for_health; then
+  echo "Docker service failed to become healthy on http://localhost:8787/health"
+  exit 1
+fi
+
+run curl -fsS "http://localhost:8787/health"
+run curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ"
+
+docker compose down
+COMPOSE_UP="0"


### PR DESCRIPTION
Adds local LGTM (Grafana/Tempo/Loki/Prom/Pyroscope) compose and app compose wiring for OTLP. Stacked PR 1/9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified observability and Docker Compose instructions; added prerequisites, combined run guidance for service + observability stack, and updated OTLP endpoint guidance.
* **New Features**
  * Added Docker Compose workflows for local development and a multi-component observability stack (Grafana, Tempo, Loki, Prometheus, Pyroscope).
* **Configuration**
  * Added SMART_ADDRESS_WIDE_EVENT_SLOW_MS environment variable and clarified .env usage and persistence guidance.
* **Tools**
  * Added utilities for freeing ports and an end-to-end verification workflow to simplify local testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->