### PR TITLE
obs: Alloy logs/metrics pipeline

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -73,6 +73,13 @@ Doporučené env proměnné:
 - `OTEL_SERVICE_VERSION` (volitelné)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (výchozí: `1` v dev, `0.05` v production)
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (výchozí: `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (výchozí: `true` v dev, `false` v production)
+
+Posílání JSON logů a Prometheus metrik do LGTM přes Alloy:
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/compose/alloy.yaml up -d
+```
 
 ## SDK pro prohlížeč (module script)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Recommended env vars:
 - `OTEL_SERVICE_VERSION` (optional)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` in dev, `0.05` in production)
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (default: `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (default: `true` in dev, `false` in production)
+
+Ship JSON logs + Prometheus metrics to LGTM via Alloy:
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/compose/alloy.yaml up -d
+```
 
 ## Browser SDK (module script)
 

--- a/apps/docs/content/cs/explanation/observability.md
+++ b/apps/docs/content/cs/explanation/observability.md
@@ -25,6 +25,7 @@ Proměnné prostředí pro observabilitu:
 - `OTEL_SERVICE_VERSION` (volitelné)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` v dev, `0.05` v production)
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (default: `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (default: `true` v dev, `false` v production)
 
 Copy-paste příklad (lokální tracing):
 
@@ -44,6 +45,12 @@ Spuštění služby a LGTM dohromady (Docker):
 docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 ```
 
+Posílání logů a metrik do LGTM přes Alloy:
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/compose/alloy.yaml up -d
+```
+
 ## Výstup
 
 - Jeden wide event na request (HTTP, RPC, MCP) s kontextem, cache výsledky, provider časy a počty výsledků.
@@ -51,6 +58,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 - Tail sampling vždy ponechá chyby, pomalé requesty a ručně označené requesty; zbytek sampleuje.
 - HTTP odpovědi obsahují `x-request-id` (pokud je poslán, vrací se zpět; jinak se generuje).
 - HTTP odpovědi obsahují `server-timing` s celkovou dobou requestu a časy providerů.
+- Při zapnutém Alloy jdou JSON logy do Loki a Prometheus metriky se remote-write do LGTM.
 
 ## Chyby
 

--- a/apps/docs/content/cs/reference/config.md
+++ b/apps/docs/content/cs/reference/config.md
@@ -54,7 +54,7 @@ Environment proměnné služby. Hodnoty se čtou z procesního prostředí.
 ## Observabilita
 
 - `SMART_ADDRESS_OTEL_ENABLED` (boolean, default `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (string, default `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (string, volitelné)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (number, default `1` v dev, `0.05` v production)

--- a/apps/docs/content/cs/reference/config.md
+++ b/apps/docs/content/cs/reference/config.md
@@ -51,6 +51,16 @@ Environment proměnné služby. Hodnoty se čtou z procesního prostředí.
 
 - `SMART_ADDRESS_DB_PATH` (string, default `data/smart-address.db` relativně k working directory služby)
 
+## Observabilita
+
+- `SMART_ADDRESS_OTEL_ENABLED` (boolean, default `true`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318/v1/traces`)
+- `OTEL_SERVICE_NAME` (string, default `smart-address-service`)
+- `OTEL_SERVICE_VERSION` (string, volitelné)
+- `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (number, default `1` v dev, `0.05` v production)
+- `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (number, default `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (boolean, default `true` v dev, `false` v production)
+
 ## Minimální příklad
 
 Volitelně přidejte `RADAR_API_KEY` pro zapnutí Radar Autocomplete nebo `HERE_API_KEY` pro zapnutí HERE Discover.

--- a/apps/docs/content/cs/reference/service-api.md
+++ b/apps/docs/content/cs/reference/service-api.md
@@ -20,7 +20,7 @@ Default: `http://localhost:8787`
 - `GET /suggest` (query parametry)
 - `POST /suggest` (JSON nebo form)
 - `POST /accept` (JSON)
-- `GET /metrics` (JSON)
+- `GET /metrics` (JSON nebo Prometheus text)
 
 Další protokoly:
 
@@ -89,9 +89,17 @@ Stejná pole jako `GET /suggest`.
 ### GET /metrics
 
 Vrací JSON snapshot metrik cache a providerů pro interní monitoring.
+Pokud `Accept` obsahuje `text/plain` nebo `application/openmetrics-text`,
+endpoint vrací Prometheus text formát.
 
 ```bash
 curl "http://localhost:8787/metrics"
+```
+
+Prometheus scrape příklad:
+
+```bash
+curl -H "accept: text/plain" "http://localhost:8787/metrics"
 ```
 
 ## Výstup
@@ -147,6 +155,14 @@ Hodnota `provider` závisí na konfiguraci (například `nominatim`, `radar-auto
     }
   ]
 }
+```
+
+### GET /metrics (200, Prometheus text)
+
+```
+smart_address_cache_requests_total 120
+smart_address_cache_hits_total 85
+smart_address_provider_calls_total{provider="nominatim"} 80
 ```
 
 ### GET /health

--- a/apps/docs/content/cs/reference/service-api.md
+++ b/apps/docs/content/cs/reference/service-api.md
@@ -159,7 +159,7 @@ Hodnota `provider` závisí na konfiguraci (například `nominatim`, `radar-auto
 
 ### GET /metrics (200, Prometheus text)
 
-```
+```prometheus
 smart_address_cache_requests_total 120
 smart_address_cache_hits_total 85
 smart_address_provider_calls_total{provider="nominatim"} 80

--- a/apps/docs/content/en/explanation/observability.md
+++ b/apps/docs/content/en/explanation/observability.md
@@ -25,6 +25,7 @@ Environment variables that control observability:
 - `OTEL_SERVICE_VERSION` (optional)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (default: `1` in dev, `0.05` in production)
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (default: `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (default: `true` in dev, `false` in production)
 
 Copy-paste example (local tracing):
 
@@ -44,6 +45,12 @@ Run the service and LGTM together (Docker):
 docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 ```
 
+Ship logs + metrics to LGTM via Alloy:
+
+```bash
+docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/compose/alloy.yaml up -d
+```
+
 ## Output
 
 - One wide event per request (HTTP, RPC, MCP) with request context, cache outcomes, provider timings, and result counts.
@@ -51,6 +58,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml up -d
 - Tail sampling keeps errors, slow requests, and manually marked requests, sampling the rest.
 - HTTP responses include `x-request-id` (echoed if provided, otherwise generated).
 - HTTP responses include `server-timing` with total request duration and provider timings.
+- When Alloy is enabled, JSON logs flow to Loki and Prometheus metrics are remote-written into LGTM.
 
 ## Errors
 

--- a/apps/docs/content/en/reference/config.md
+++ b/apps/docs/content/en/reference/config.md
@@ -51,6 +51,16 @@ Service environment variables. All values are read from the process environment.
 
 - `SMART_ADDRESS_DB_PATH` (string, default `data/smart-address.db` relative to the service working directory)
 
+## Observability
+
+- `SMART_ADDRESS_OTEL_ENABLED` (boolean, default `true`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318/v1/traces`)
+- `OTEL_SERVICE_NAME` (string, default `smart-address-service`)
+- `OTEL_SERVICE_VERSION` (string, optional)
+- `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (number, default `1` in dev, `0.05` in production)
+- `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (number, default `2000`)
+- `SMART_ADDRESS_LOG_RAW_QUERY` (boolean, default `true` in dev, `false` in production)
+
 ## Minimal example
 
 Optional: add `RADAR_API_KEY` to enable Radar Autocomplete or `HERE_API_KEY` to enable HERE Discover.

--- a/apps/docs/content/en/reference/config.md
+++ b/apps/docs/content/en/reference/config.md
@@ -54,7 +54,7 @@ Service environment variables. All values are read from the process environment.
 ## Observability
 
 - `SMART_ADDRESS_OTEL_ENABLED` (boolean, default `true`)
-- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318/v1/traces`)
+- `OTEL_EXPORTER_OTLP_ENDPOINT` (string, default `http://localhost:4318`)
 - `OTEL_SERVICE_NAME` (string, default `smart-address-service`)
 - `OTEL_SERVICE_VERSION` (string, optional)
 - `SMART_ADDRESS_WIDE_EVENT_SAMPLE_RATE` (number, default `1` in dev, `0.05` in production)

--- a/apps/docs/content/en/reference/service-api.md
+++ b/apps/docs/content/en/reference/service-api.md
@@ -20,7 +20,7 @@ Default: `http://localhost:8787`
 - `GET /suggest` (query params)
 - `POST /suggest` (JSON or form)
 - `POST /accept` (JSON)
-- `GET /metrics` (JSON)
+- `GET /metrics` (JSON or Prometheus text)
 
 Other protocols:
 
@@ -89,9 +89,17 @@ Same fields as `GET /suggest`.
 ### GET /metrics
 
 Returns a JSON snapshot of cache and provider metrics for internal monitoring.
+If the `Accept` header includes `text/plain` or `application/openmetrics-text`,
+the endpoint responds in Prometheus text format.
 
 ```bash
 curl "http://localhost:8787/metrics"
+```
+
+Prometheus scrape example:
+
+```bash
+curl -H "accept: text/plain" "http://localhost:8787/metrics"
 ```
 
 ## Output
@@ -147,6 +155,14 @@ The `provider` value depends on configured providers (for example, `nominatim`, 
     }
   ]
 }
+```
+
+### GET /metrics (200, Prometheus text)
+
+```
+smart_address_cache_requests_total 120
+smart_address_cache_hits_total 85
+smart_address_provider_calls_total{provider="nominatim"} 80
 ```
 
 ### GET /health

--- a/apps/docs/content/en/reference/service-api.md
+++ b/apps/docs/content/en/reference/service-api.md
@@ -159,7 +159,7 @@ The `provider` value depends on configured providers (for example, `nominatim`, 
 
 ### GET /metrics (200, Prometheus text)
 
-```
+```prometheus
 smart_address_cache_requests_total 120
 smart_address_cache_hits_total 85
 smart_address_provider_calls_total{provider="nominatim"} 80

--- a/apps/service-bun/src/http.ts
+++ b/apps/service-bun/src/http.ts
@@ -61,13 +61,18 @@ const errorResponse = (message: string, status = 400) =>
 
 const acceptsPrometheus = (request: HttpServerRequest): boolean => {
   const accept = request.headers["accept"];
-  if (typeof accept !== "string") {
+  const value = Array.isArray(accept)
+    ? accept.join(",")
+    : typeof accept === "string"
+      ? accept
+      : undefined;
+  if (!value) {
     return false;
   }
-  const value = accept.toLowerCase();
+  const normalized = value.toLowerCase();
   return (
-    value.includes("text/plain") ||
-    value.includes("application/openmetrics-text")
+    normalized.includes("text/plain") ||
+    normalized.includes("application/openmetrics-text")
   );
 };
 

--- a/apps/service-bun/src/main.ts
+++ b/apps/service-bun/src/main.ts
@@ -1,7 +1,7 @@
 import { layer as fetchHttpClientLayer } from "@effect/platform/FetchHttpClient";
 import { serve } from "@effect/platform/HttpLayerRouter";
 import { BunHttpServer, BunRuntime } from "@effect/platform-bun";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Logger } from "effect";
 import { AddressAcceptLogSqlite } from "./accept-log";
 import {
   AddressCachedSuggestorLayer,
@@ -72,6 +72,7 @@ const serverLayer = Layer.unwrapEffect(
       serviceVersion: observability.otelServiceVersion,
       sampleRate: observability.wideEventSampleRate,
       slowThresholdMs: observability.wideEventSlowMs,
+      logRawQuery: observability.logRawQuery,
     };
 
     return serve(appLayer).pipe(
@@ -82,4 +83,6 @@ const serverLayer = Layer.unwrapEffect(
   })
 );
 
-BunRuntime.runMain(Layer.launch(serverLayer));
+const main = Layer.launch(serverLayer).pipe(Effect.provide(Logger.json));
+
+BunRuntime.runMain(main);

--- a/apps/service-bun/src/metrics.ts
+++ b/apps/service-bun/src/metrics.ts
@@ -192,7 +192,7 @@ const metricLine = (
   name: string,
   value: number,
   labels: Record<string, string | number | undefined> = {}
-): string => `${name}${formatLabels(labels)} ${value}\n`;
+): string => `${name}${formatLabels(labels)} ${value}`;
 
 export const renderPrometheusMetrics = (
   snapshot: AddressMetricsSnapshot

--- a/apps/service-bun/src/metrics.ts
+++ b/apps/service-bun/src/metrics.ts
@@ -171,6 +171,139 @@ const toSnapshot = (state: MetricsState): AddressMetricsSnapshot => {
   };
 };
 
+const escapeLabelValue = (value: string): string =>
+  value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+
+const formatLabels = (
+  labels: Record<string, string | number | undefined>
+): string => {
+  const entries = Object.entries(labels).filter(
+    ([, value]) => value !== undefined
+  );
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries
+    .map(([key, value]) => `${key}="${escapeLabelValue(String(value))}"`)
+    .join(",")}}`;
+};
+
+const metricLine = (
+  name: string,
+  value: number,
+  labels: Record<string, string | number | undefined> = {}
+): string => `${name}${formatLabels(labels)} ${value}\n`;
+
+export const renderPrometheusMetrics = (
+  snapshot: AddressMetricsSnapshot
+): string => {
+  const lines: string[] = [];
+
+  lines.push("# HELP smart_address_cache_requests_total Cache requests.");
+  lines.push("# TYPE smart_address_cache_requests_total counter");
+  lines.push(
+    metricLine("smart_address_cache_requests_total", snapshot.cache.requests)
+  );
+
+  lines.push("# HELP smart_address_cache_hits_total Cache hits.");
+  lines.push("# TYPE smart_address_cache_hits_total counter");
+  lines.push(metricLine("smart_address_cache_hits_total", snapshot.cache.hits));
+
+  lines.push("# HELP smart_address_cache_l1_hits_total L1 cache hits.");
+  lines.push("# TYPE smart_address_cache_l1_hits_total counter");
+  lines.push(metricLine("smart_address_cache_l1_hits_total", snapshot.cache.l1Hits));
+
+  lines.push("# HELP smart_address_cache_l1_misses_total L1 cache misses.");
+  lines.push("# TYPE smart_address_cache_l1_misses_total counter");
+  lines.push(
+    metricLine("smart_address_cache_l1_misses_total", snapshot.cache.l1Misses)
+  );
+
+  lines.push("# HELP smart_address_cache_l2_hits_total L2 cache hits.");
+  lines.push("# TYPE smart_address_cache_l2_hits_total counter");
+  lines.push(metricLine("smart_address_cache_l2_hits_total", snapshot.cache.l2Hits));
+
+  lines.push("# HELP smart_address_cache_l2_misses_total L2 cache misses.");
+  lines.push("# TYPE smart_address_cache_l2_misses_total counter");
+  lines.push(
+    metricLine("smart_address_cache_l2_misses_total", snapshot.cache.l2Misses)
+  );
+
+  lines.push("# HELP smart_address_cache_hit_rate Cache hit rate.");
+  lines.push("# TYPE smart_address_cache_hit_rate gauge");
+  lines.push(metricLine("smart_address_cache_hit_rate", snapshot.cache.hitRate));
+
+  lines.push("# HELP smart_address_cache_l1_hit_rate L1 cache hit rate.");
+  lines.push("# TYPE smart_address_cache_l1_hit_rate gauge");
+  lines.push(
+    metricLine("smart_address_cache_l1_hit_rate", snapshot.cache.l1HitRate)
+  );
+
+  lines.push("# HELP smart_address_cache_l2_hit_rate L2 cache hit rate.");
+  lines.push("# TYPE smart_address_cache_l2_hit_rate gauge");
+  lines.push(
+    metricLine("smart_address_cache_l2_hit_rate", snapshot.cache.l2HitRate)
+  );
+
+  lines.push("# HELP smart_address_provider_calls_total Provider calls.");
+  lines.push("# TYPE smart_address_provider_calls_total counter");
+  lines.push("# HELP smart_address_provider_errors_total Provider errors.");
+  lines.push("# TYPE smart_address_provider_errors_total counter");
+  lines.push("# HELP smart_address_provider_latency_ms Provider latency (ms).");
+  lines.push("# TYPE smart_address_provider_latency_ms gauge");
+
+  for (const provider of snapshot.providers) {
+    lines.push(
+      metricLine("smart_address_provider_calls_total", provider.calls, {
+        provider: provider.provider,
+      })
+    );
+    lines.push(
+      metricLine("smart_address_provider_errors_total", provider.errors, {
+        provider: provider.provider,
+      })
+    );
+    lines.push(
+      metricLine("smart_address_provider_latency_ms", provider.latencyMs.avg, {
+        provider: provider.provider,
+        stat: "avg",
+      })
+    );
+    lines.push(
+      metricLine("smart_address_provider_latency_ms", provider.latencyMs.min ?? 0, {
+        provider: provider.provider,
+        stat: "min",
+      })
+    );
+    lines.push(
+      metricLine("smart_address_provider_latency_ms", provider.latencyMs.max ?? 0, {
+        provider: provider.provider,
+        stat: "max",
+      })
+    );
+  }
+
+  lines.push("# HELP smart_address_metrics_started_at_seconds Metrics start time.");
+  lines.push("# TYPE smart_address_metrics_started_at_seconds gauge");
+  lines.push(
+    metricLine(
+      "smart_address_metrics_started_at_seconds",
+      Math.floor(snapshot.startedAt / 1000)
+    )
+  );
+
+  lines.push("# HELP smart_address_metrics_updated_at_seconds Metrics update time.");
+  lines.push("# TYPE smart_address_metrics_updated_at_seconds gauge");
+  lines.push(
+    metricLine(
+      "smart_address_metrics_updated_at_seconds",
+      Math.floor(snapshot.updatedAt / 1000)
+    )
+  );
+
+  return `${lines.join("\n")}\n`;
+};
+
 export const AddressMetricsLayer = Layer.effect(
   AddressMetrics,
   Effect.gen(function* () {

--- a/apps/service-bun/test/http-helpers.ts
+++ b/apps/service-bun/test/http-helpers.ts
@@ -19,6 +19,15 @@ export const parseJsonResponse = (
     return { web, body };
   });
 
+export const parseTextResponse = (
+  response: HttpServerResponse
+): Effect.Effect<{ web: Response; body: string }> =>
+  Effect.gen(function* () {
+    const web = toWeb(response);
+    const body = yield* Effect.promise(() => web.text());
+    return { web, body };
+  });
+
 export const makeRequestUrl = (path: string) => new URL(path, testOrigin);
 
 export const makeSuggestPostRequest = (body: unknown) =>

--- a/apps/service-bun/test/mcp.test.ts
+++ b/apps/service-bun/test/mcp.test.ts
@@ -26,6 +26,7 @@ const requestEventConfigLayer = RequestEventConfigLayer({
   serviceVersion: "test",
   sampleRate: 1,
   slowThresholdMs: 0,
+  logRawQuery: true,
 });
 
 describe("mcp toolkit", () => {

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -28,7 +28,7 @@ loki.source.docker "smart_address" {
   targets       = discovery.docker.containers.targets
   relabel_rules = discovery.relabel.smart_address_logs.rules
   labels = {
-    job = "smart-address"
+    job = "smart-address",
   }
   forward_to = [loki.process.smart_address.receiver]
 }
@@ -38,26 +38,26 @@ loki.process "smart_address" {
 
   stage.json {
     expressions = {
-      logLevel = "logLevel"
-      message  = "message"
+      logLevel = "logLevel",
+      message  = "message",
     }
   }
 
   stage.json {
     source = "message"
     expressions = {
-      service    = "service"
-      kind       = "kind"
-      statusCode = "statusCode"
+      service    = "service",
+      kind       = "kind",
+      statusCode = "statusCode",
     }
   }
 
   stage.labels {
     values = {
-      service     = "service"
-      kind        = "kind"
-      status_code = "statusCode"
-      level       = "logLevel"
+      service     = "service",
+      kind        = "kind",
+      status_code = "statusCode",
+      level       = "logLevel",
     }
   }
 }
@@ -71,13 +71,13 @@ loki.write "lgtm" {
 prometheus.scrape "smart_address" {
   targets = [
     {
-      "__address__"     = "smart-address:8787"
-      "__metrics_path__" = "/metrics"
-      "job"             = "smart-address"
+      "__address__"      = "smart-address:8787",
+      "__metrics_path__" = "/metrics",
+      "job"              = "smart-address",
     },
   ]
   http_headers = {
-    Accept = ["application/openmetrics-text", "text/plain; q=0.9"]
+    Accept = ["application/openmetrics-text", "text/plain; q=0.9"],
   }
   scrape_interval = "15s"
   forward_to      = [prometheus.remote_write.lgtm.receiver]

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -38,10 +38,17 @@ loki.process "smart_address" {
 
   stage.json {
     expressions = {
-      logLevel   = "logLevel"
-      service    = "message[0].service"
-      kind       = "message[0].kind"
-      statusCode = "message[0].statusCode"
+      logLevel = "logLevel"
+      message  = "message"
+    }
+  }
+
+  stage.json {
+    source = "message"
+    expressions = {
+      service    = "[0].service"
+      kind       = "[0].kind"
+      statusCode = "[0].statusCode"
     }
   }
 
@@ -69,6 +76,9 @@ prometheus.scrape "smart_address" {
       "job"             = "smart-address"
     },
   ]
+  http_headers = {
+    Accept = ["application/openmetrics-text", "text/plain; q=0.9"]
+  }
   scrape_interval = "15s"
   forward_to      = [prometheus.remote_write.lgtm.receiver]
 }

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -85,6 +85,6 @@ prometheus.scrape "smart_address" {
 
 prometheus.remote_write "lgtm" {
   endpoint {
-    url = "http://lgtm:9009/api/v1/push"
+    url = "http://lgtm:9090/api/v1/write"
   }
 }

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -1,0 +1,80 @@
+logging {
+  level  = "info"
+  format = "json"
+}
+
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "smart_address_logs" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = ".*/.*smart-address.*"
+    action        = "keep"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+}
+
+loki.source.docker "smart_address" {
+  host          = "unix:///var/run/docker.sock"
+  targets       = discovery.docker.containers.targets
+  relabel_rules = discovery.relabel.smart_address_logs.rules
+  labels = {
+    job = "smart-address"
+  }
+  forward_to = [loki.process.smart_address.receiver]
+}
+
+loki.process "smart_address" {
+  forward_to = [loki.write.lgtm.receiver]
+
+  stage.json {
+    expressions = {
+      logLevel   = "logLevel"
+      service    = "message[0].service"
+      kind       = "message[0].kind"
+      statusCode = "message[0].statusCode"
+    }
+  }
+
+  stage.labels {
+    values = {
+      service     = "service"
+      kind        = "kind"
+      status_code = "statusCode"
+      level       = "logLevel"
+    }
+  }
+}
+
+loki.write "lgtm" {
+  endpoint {
+    url = "http://lgtm:3100/loki/api/v1/push"
+  }
+}
+
+prometheus.scrape "smart_address" {
+  targets = [
+    {
+      "__address__"     = "smart-address:8787"
+      "__metrics_path__" = "/metrics"
+      "job"             = "smart-address"
+    },
+  ]
+  scrape_interval = "15s"
+  forward_to      = [prometheus.remote_write.lgtm.receiver]
+}
+
+prometheus.remote_write "lgtm" {
+  endpoint {
+    url = "http://lgtm:9009/api/v1/push"
+  }
+}

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -46,9 +46,9 @@ loki.process "smart_address" {
   stage.json {
     source = "message"
     expressions = {
-      service    = "[0].service"
-      kind       = "[0].kind"
-      statusCode = "[0].statusCode"
+      service    = "service"
+      kind       = "kind"
+      statusCode = "statusCode"
     }
   }
 

--- a/deploy/compose/alloy.yaml
+++ b/deploy/compose/alloy.yaml
@@ -1,0 +1,22 @@
+services:
+  alloy:
+    image: grafana/alloy
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    user: "0"
+    ports:
+      - "12345:12345"
+    volumes:
+      - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - alloy-data:/var/lib/alloy/data
+    depends_on:
+      - lgtm
+      - smart-address
+    restart: unless-stopped
+
+volumes:
+  alloy-data:

--- a/deploy/compose/alloy.yaml
+++ b/deploy/compose/alloy.yaml
@@ -1,16 +1,19 @@
 services:
   alloy:
-    image: grafana/alloy
+    image: grafana/alloy:v1.12.1
     command:
       - run
       - --server.http.listen-addr=0.0.0.0:12345
       - --storage.path=/var/lib/alloy/data
       - /etc/alloy/config.alloy
+    # Root is required for docker.sock access and future eBPF components; run in trusted environments.
     user: "0"
     ports:
       - "12345:12345"
     volumes:
+      # Keep Alloy config read-only to prevent in-container edits.
       - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
+      # docker.sock grants access to container logs; consider docker group for non-root alternatives.
       - /var/run/docker.sock:/var/run/docker.sock
       - alloy-data:/var/lib/alloy/data
     depends_on:


### PR DESCRIPTION
Adds Alloy config + compose for Loki/Prometheus pipelines and JSON logging for wide events. Stacked PR 2/9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * /metrics now supports Prometheus text format alongside JSON.
  * Alloy integration to send JSON logs and Prometheus metrics to LGTM; example compose command provided.
  * New observability option to control raw query logging; events now include query hashes and capture trace/span IDs.

* **Documentation**
  * Updated observability and API docs (EN/CS) with new env vars, examples and deployment instructions.

* **Tests**
  * Added tests for Prometheus output and raw-query redaction/tracing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->