### PR TITLE
obs: fix tracing spans + cache/sqlite spans

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -75,6 +75,8 @@ Doporučené env proměnné:
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (výchozí: `2000`)
 - `SMART_ADDRESS_LOG_RAW_QUERY` (výchozí: `true` v dev, `false` v production)
 
+Příchozí hlavička `traceparent` pokračuje upstream trace.
+
 Posílání JSON logů a Prometheus metrik do LGTM přes Alloy:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Recommended env vars:
 - `SMART_ADDRESS_WIDE_EVENT_SLOW_MS` (default: `2000`)
 - `SMART_ADDRESS_LOG_RAW_QUERY` (default: `true` in dev, `false` in production)
 
+Incoming `traceparent` headers are honored to continue upstream traces.
+
 Ship JSON logs + Prometheus metrics to LGTM via Alloy:
 
 ```bash

--- a/apps/docs/content/cs/explanation/observability.md
+++ b/apps/docs/content/cs/explanation/observability.md
@@ -58,6 +58,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/c
 - Tail sampling vždy ponechá chyby, pomalé requesty a ručně označené requesty; zbytek sampleuje.
 - HTTP odpovědi obsahují `x-request-id` (pokud je poslán, vrací se zpět; jinak se generuje).
 - HTTP odpovědi obsahují `server-timing` s celkovou dobou requestu a časy providerů.
+- Hlavička `traceparent` pokračuje upstream trace.
 - Při zapnutém Alloy jdou JSON logy do Loki a Prometheus metriky se remote-write do LGTM.
 
 ## Chyby

--- a/apps/docs/content/cs/reference/service-api.md
+++ b/apps/docs/content/cs/reference/service-api.md
@@ -27,6 +27,11 @@ Další protokoly:
 - MCP: `POST /mcp` (viz: [MCP nástroj](/cs/reference/mcp-tool))
 - Effect RPC: `/rpc` (viz: [Effect RPC](/cs/reference/rpc))
 
+### Hlavičky
+
+- `x-request-id` (volitelné; vrací se zpět)
+- `traceparent` (volitelné; W3C trace context)
+
 ### GET /suggest (query parametry)
 
 - Povinné: `text` (string) nebo `q` (alias)

--- a/apps/docs/content/en/explanation/observability.md
+++ b/apps/docs/content/en/explanation/observability.md
@@ -58,6 +58,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/c
 - Tail sampling keeps errors, slow requests, and manually marked requests, sampling the rest.
 - HTTP responses include `x-request-id` (echoed if provided, otherwise generated).
 - HTTP responses include `server-timing` with total request duration and provider timings.
+- Incoming `traceparent` headers continue an upstream trace.
 - When Alloy is enabled, JSON logs flow to Loki and Prometheus metrics are remote-written into LGTM.
 
 ## Errors

--- a/apps/docs/content/en/reference/service-api.md
+++ b/apps/docs/content/en/reference/service-api.md
@@ -27,6 +27,11 @@ Other protocols:
 - MCP: `POST /mcp` (see: [MCP tool](/reference/mcp-tool))
 - Effect RPC: `/rpc` (see: [Effect RPC](/reference/rpc))
 
+### Headers
+
+- `x-request-id` (optional; echoed back)
+- `traceparent` (optional; W3C trace context)
+
 ### GET /suggest (query parameters)
 
 - Required: `text` (string) or `q` (alias)

--- a/apps/service-bun/package.json
+++ b/apps/service-bun/package.json
@@ -16,6 +16,7 @@
     "@effect/platform": "catalog:prod",
     "@effect/platform-bun": "catalog:prod",
     "@effect/rpc": "catalog:prod",
+    "@opentelemetry/api": "^1.9.0",
     "@smart-address/core": "workspace:*",
     "@smart-address/integrations": "workspace:*",
     "@smart-address/rpc": "workspace:*",

--- a/apps/service-bun/src/accept-log.ts
+++ b/apps/service-bun/src/accept-log.ts
@@ -1,7 +1,11 @@
 import { Context, Effect, Layer } from "effect";
 import type { AcceptRequest } from "./accept-request";
 import { buildQueryLogFields } from "./log-fields";
-import { type AddressSqliteConfig, openAddressSqlite } from "./sqlite";
+import {
+  type AddressSqliteConfig,
+  openAddressSqlite,
+  sqliteSpanAttributes,
+} from "./sqlite";
 
 export interface AddressAcceptLog {
   readonly record: (request: AcceptRequest) => Effect.Effect<void>;
@@ -54,7 +58,12 @@ export const AddressAcceptLogSqlite = (config: AddressSqliteConfig = {}) =>
               request.resultCount ?? null,
               JSON.stringify(suggestion)
             );
-          }),
+          }).pipe(
+            Effect.withSpan("sqlite.write.accept_log", {
+              kind: "client",
+              attributes: sqliteSpanAttributes("INSERT"),
+            })
+          ),
       };
     })
   );

--- a/apps/service-bun/src/cache.ts
+++ b/apps/service-bun/src/cache.ts
@@ -161,9 +161,9 @@ export const AddressCacheStoreSqlite = (config: AddressSqliteConfig = {}) =>
               Effect.withSpan("sqlite.write.cache", {
                 kind: "client",
                 attributes: sqliteSpanAttributes("INSERT"),
-              })
-            )
-            .pipe(Effect.asVoid),
+              }),
+              Effect.asVoid
+            ),
       };
     })
   );

--- a/apps/service-bun/src/cache.ts
+++ b/apps/service-bun/src/cache.ts
@@ -162,7 +162,7 @@ export const AddressCacheStoreSqlite = (config: AddressSqliteConfig = {}) =>
                 kind: "client",
                 attributes: sqliteSpanAttributes("INSERT"),
               }),
-              Effect.asVoid
+              Effect.tap(Effect.void)
             ),
       };
     })

--- a/apps/service-bun/src/cache.ts
+++ b/apps/service-bun/src/cache.ts
@@ -25,7 +25,11 @@ import type { SuggestRequest } from "./request";
 import { type CacheEventUpdate, RequestEvent } from "./request-event";
 import { AddressSearchLog } from "./search-log";
 import { AddressSuggestor } from "./service";
-import { type AddressSqliteConfig, openAddressSqlite } from "./sqlite";
+import {
+  type AddressSqliteConfig,
+  openAddressSqlite,
+  sqliteSpanAttributes,
+} from "./sqlite";
 
 interface AddressCacheEntry {
   readonly storedAt: number;
@@ -128,7 +132,12 @@ export const AddressCacheStoreSqlite = (config: AddressSqliteConfig = {}) =>
               remove.run(key);
               return null;
             }
-          }),
+          }).pipe(
+            Effect.withSpan("sqlite.read.cache", {
+              kind: "client",
+              attributes: sqliteSpanAttributes("SELECT"),
+            })
+          ),
         set: (key, entry) =>
           Effect.sync(() => {
             const storedAt = Number.isFinite(entry.storedAt)
@@ -147,7 +156,14 @@ export const AddressCacheStoreSqlite = (config: AddressSqliteConfig = {}) =>
               expiresAt,
               JSON.stringify(entry)
             );
-          }).pipe(Effect.asVoid),
+          })
+            .pipe(
+              Effect.withSpan("sqlite.write.cache", {
+                kind: "client",
+                attributes: sqliteSpanAttributes("INSERT"),
+              })
+            )
+            .pipe(Effect.asVoid),
       };
     })
   );
@@ -209,6 +225,8 @@ const computePolicy = (
 const makeCacheKey = (request: SuggestRequest) =>
   `${request.strategy}:${addressQueryKey(request.query)}`;
 
+const cacheKeyHash = (key: string) => Math.abs(hash(key)).toString(16);
+
 class AddressCacheKey implements Equal {
   readonly key: string;
   readonly request: SuggestRequest;
@@ -257,6 +275,7 @@ export const AddressSuggestionCacheLayer = (config: AddressCacheConfig = {}) =>
         Object.entries(config).filter(([, value]) => value !== undefined)
       ) as Partial<AddressCacheConfig>;
       const resolved = { ...defaultCacheConfig, ...overrides };
+      const l1TtlMs = toMillis(resolved.l1Ttl);
       const recordCacheMetric = (event: CacheMetricEvent) =>
         metrics.recordCache(event).pipe(Effect.catchAll(() => Effect.void));
 
@@ -307,7 +326,19 @@ export const AddressSuggestionCacheLayer = (config: AddressCacheConfig = {}) =>
             expiresAt: now + policy.ttlMs,
             result,
           };
-          yield* store.set(key, entry);
+          const keyHash = cacheKeyHash(key);
+          yield* store
+            .set(key, entry)
+            .pipe(
+              Effect.withSpan("cache.set", {
+                kind: "internal",
+                attributes: {
+                  "cache.layer": "l2",
+                  "cache.key_hash": keyHash,
+                  "cache.ttl_ms": policy.ttlMs,
+                },
+              })
+            );
           yield* recordCacheUpdateWith(
             {
               ttlMs: policy.ttlMs,
@@ -405,8 +436,27 @@ export const AddressSuggestionCacheLayer = (config: AddressCacheConfig = {}) =>
 
       const lookup = (entryKey: AddressCacheKey) =>
         Effect.gen(function* () {
-          const cached = yield* store.get(entryKey.key);
           const now = yield* currentTimeMillis;
+          const keyHash = cacheKeyHash(entryKey.key);
+          const cached = yield* store
+            .get(entryKey.key)
+            .pipe(
+              Effect.withSpan("cache.get", {
+                kind: "internal",
+                attributes: {
+                  "cache.layer": "l2",
+                  "cache.key_hash": keyHash,
+                },
+              }),
+              Effect.tap((entry) =>
+                Effect.annotateCurrentSpan({
+                  "cache.hit": Boolean(entry),
+                  "cache.ttl_ms": entry
+                    ? Math.max(0, entry.expiresAt - now)
+                    : undefined,
+                })
+              )
+            );
           if (!cached || cached.expiresAt <= now) {
             return yield* fetchAndStore(entryKey);
           }
@@ -430,12 +480,16 @@ export const AddressSuggestionCacheLayer = (config: AddressCacheConfig = {}) =>
               fetch,
               requestEvent
             );
+            const keyHash = cacheKeyHash(entryKey.key);
             const result = yield* l1
               .getEither(entryKey)
               .pipe(
                 Effect.tap((value) =>
                   Effect.all(
                     [
+                      Effect.annotateCurrentSpan({
+                        "cache.hit": Either.isLeft(value),
+                      }),
                       recordCacheMetric(
                         Either.isLeft(value) ? "l1-hit" : "l1-miss"
                       ),
@@ -446,7 +500,15 @@ export const AddressSuggestionCacheLayer = (config: AddressCacheConfig = {}) =>
                     ],
                     { concurrency: "unbounded" }
                   ).pipe(Effect.asVoid)
-                )
+                ),
+                Effect.withSpan("cache.get", {
+                  kind: "internal",
+                  attributes: {
+                    "cache.layer": "l1",
+                    "cache.key_hash": keyHash,
+                    "cache.ttl_ms": l1TtlMs,
+                  },
+                })
               );
             return Either.isLeft(result) ? result.left : result.right;
           }),

--- a/apps/service-bun/src/http.ts
+++ b/apps/service-bun/src/http.ts
@@ -85,7 +85,13 @@ const readHeaderValue = (
   if (!value) {
     return undefined;
   }
-  return Array.isArray(value) ? value[0] : value;
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return undefined;
 };
 
 const traceparentPattern =

--- a/apps/service-bun/src/http.ts
+++ b/apps/service-bun/src/http.ts
@@ -103,6 +103,9 @@ const parseTraceparent = (value: string): SpanContext | undefined => {
     return undefined;
   }
   const [version, traceId, spanId, flags] = trimmed.split("-");
+  if (version === "ff") {
+    return undefined;
+  }
   if (version.length !== 2) {
     return undefined;
   }

--- a/apps/service-bun/src/search-log.ts
+++ b/apps/service-bun/src/search-log.ts
@@ -2,7 +2,11 @@ import type { AddressSuggestionResult } from "@smart-address/core";
 import { Context, Effect, Layer } from "effect";
 import { buildQueryLogFields } from "./log-fields";
 import type { SuggestRequest } from "./request";
-import { type AddressSqliteConfig, openAddressSqlite } from "./sqlite";
+import {
+  type AddressSqliteConfig,
+  openAddressSqlite,
+  sqliteSpanAttributes,
+} from "./sqlite";
 
 export interface AddressSearchLog {
   readonly record: (
@@ -46,7 +50,12 @@ export const AddressSearchLogSqlite = (config: AddressSqliteConfig = {}) =>
               cacheKey,
               JSON.stringify(result)
             );
-          }),
+          }).pipe(
+            Effect.withSpan("sqlite.write.search_log", {
+              kind: "client",
+              attributes: sqliteSpanAttributes("INSERT"),
+            })
+          ),
       };
     })
   );

--- a/apps/service-bun/src/sqlite.ts
+++ b/apps/service-bun/src/sqlite.ts
@@ -96,3 +96,8 @@ export const openAddressSqlite = (config: AddressSqliteConfig = {}) => {
   migrate(db);
   return { db, path: dbPath };
 };
+
+export const sqliteSpanAttributes = (operation: string) => ({
+  "db.system": "sqlite",
+  "db.operation": operation,
+});

--- a/packages/core/src/address.ts
+++ b/packages/core/src/address.ts
@@ -210,7 +210,8 @@ const recordProviderError = (
       onNone: () => Effect.void,
       onSome: (span) =>
         Effect.sync(() => {
-          span.event("exception", BigInt(Date.now()), {
+          const timestampNs = BigInt(Date.now()) * 1_000_000n;
+          span.event("exception", timestampNs, {
             "exception.type": errorType,
             "exception.message": errorMessage,
           });
@@ -230,7 +231,6 @@ const runProvider = <R>(provider: AddressProvider<R>, query: AddressQuery) =>
     Effect.withSpan("address.provider", {
       kind: "client",
       attributes: {
-        "address.provider": provider.name,
         "provider.name": provider.name,
         "provider.kind": readProviderKind(provider),
       },

--- a/packages/core/src/address.ts
+++ b/packages/core/src/address.ts
@@ -1,4 +1,4 @@
-import { Context, Data, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer, Option } from "effect";
 import { type DurationInput, toMillis } from "effect/Duration";
 
 export type AddressStrategy = "fast" | "reliable";
@@ -174,24 +174,73 @@ export interface AddressSuggestionServiceOptions {
   readonly stopAtLimit?: boolean;
 }
 
+const readProviderKind = (provider: AddressProvider<unknown>): string => {
+  const candidate = (provider as { kind?: string }).kind;
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : "unknown";
+};
+
+const errorTypeFromProviderError = (error: AddressProviderError): string => {
+  if (error.cause instanceof Error && error.cause.name.length > 0) {
+    return error.cause.name;
+  }
+  return error._tag ?? "AddressProviderError";
+};
+
+const recordProviderError = (
+  provider: AddressProvider<unknown>,
+  error: AddressProviderError
+) => {
+  const providerKind = readProviderKind(provider);
+  const errorType = errorTypeFromProviderError(error);
+  const errorMessage = error.message;
+
+  return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan({
+      "provider.name": provider.name,
+      "provider.kind": providerKind,
+      "provider.error": true,
+      "provider.error_type": errorType,
+      "provider.error_message": errorMessage,
+    });
+
+    const maybeSpan = yield* Effect.option(Effect.currentSpan);
+    yield* Option.match(maybeSpan, {
+      onNone: () => Effect.void,
+      onSome: (span) =>
+        Effect.sync(() => {
+          span.event("exception", BigInt(Date.now()), {
+            "exception.type": errorType,
+            "exception.message": errorMessage,
+          });
+        }),
+    });
+  }).pipe(Effect.catchAll(() => Effect.void));
+};
+
 const runProvider = <R>(provider: AddressProvider<R>, query: AddressQuery) =>
   provider.suggest(query).pipe(
+    Effect.mapError((error) => normalizeProviderError(provider.name, error)),
+    Effect.tapError((error) => recordProviderError(provider, error)),
     Effect.map((suggestions) => ({
       suggestions,
       error: null as AddressProviderError | null,
     })),
-    Effect.catchAll((error) =>
-      Effect.succeed({
-        suggestions: [],
-        error: normalizeProviderError(provider.name, error),
-      })
-    ),
     Effect.withSpan("address.provider", {
       kind: "client",
       attributes: {
         "address.provider": provider.name,
+        "provider.name": provider.name,
+        "provider.kind": readProviderKind(provider),
       },
-    })
+    }),
+    Effect.catchAll((error) =>
+      Effect.succeed({
+        suggestions: [],
+        error,
+      })
+    )
   );
 
 const isPlan = <R>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@effect/rpc':
         specifier: catalog:prod
         version: 0.73.0(@effect/platform@0.94.0(effect@3.19.13))(effect@3.19.13)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@smart-address/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -6115,8 +6118,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
     optional: true
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:


### PR DESCRIPTION
Refactors request event handling for correct span status, adds traceparent support, provider error span annotations, and cache/sqlite spans. Stacked PR 3/9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for W3C `traceparent` headers to continue upstream traces.
  * Optional `x-request-id` header echoed for request correlation.

* **Documentation**
  * Updated Observability and API reference docs to describe `traceparent` and `x-request-id`.

* **Tests**
  * Added tests verifying that `traceparent` headers are continued and provider spans include error annotations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->