### PR TITLE
obs: pyroscope.ebpf profiling

### DIFF
--- a/apps/docs/content/cs/explanation/observability.md
+++ b/apps/docs/content/cs/explanation/observability.md
@@ -61,6 +61,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/c
 - Hlavička `traceparent` pokračuje upstream trace.
 - Při zapnutém Alloy jdou JSON logy do Loki a Prometheus metriky se remote-write do LGTM.
 - Na Linuxu Beyla eBPF přidává RED + síťové metriky; volitelné Beyla spany jsou oddělené od Effect trace.
+- Na Linuxu Pyroscope eBPF přidává CPU profily v Pyroscope.
 
 ## Chyby
 

--- a/apps/docs/content/cs/how-to/ebpf.md
+++ b/apps/docs/content/cs/how-to/ebpf.md
@@ -1,12 +1,13 @@
 # Linux eBPF observabilita (Beyla)
 
 ## Cíl
-Sbírat eBPF RED + síťové metriky (a volitelně spany) pro službu smart-address na Linuxu.
+Sbírat eBPF RED + síťové metriky (a volitelně spany) plus CPU profily pro službu smart-address na Linuxu.
 
 ## Předpoklady
 - Linux kernel >= 5.8 s BTF (`/sys/kernel/btf/vmlinux`).
 - Docker běžící na Linux hostu/VM (eBPF je pouze pro Linux).
 - `deploy/compose/obs.yaml`, `deploy/compose/app.yaml`, `deploy/compose/alloy.yaml`.
+- Alloy běží jako root s host PID namespace a namountovaným `/tmp/symb-cache`.
 
 ## Vstupy
 - Volitelně: `SMART_ADDRESS_BEYLA_OTLP_ENDPOINT` pro přepsání OTLP endpointu pro Beyla spany (výchozí `lgtm:4317`).
@@ -28,6 +29,7 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 
 ## Výstup
 - Grafana ukazuje Beyla RED + síťové metriky v Prometheus datasource.
+- Pyroscope zobrazuje CPU profily pro `smart-address` po zátěži.
 - Pokud je zapnuto, Beyla spany se zobrazí v Tempo (odděleně od Effect trace).
 
 ## Chyby

--- a/apps/docs/content/en/explanation/observability.md
+++ b/apps/docs/content/en/explanation/observability.md
@@ -61,6 +61,7 @@ docker compose -f deploy/compose/obs.yaml -f deploy/compose/app.yaml -f deploy/c
 - Incoming `traceparent` headers continue an upstream trace.
 - When Alloy is enabled, JSON logs flow to Loki and Prometheus metrics are remote-written into LGTM.
 - On Linux, Beyla eBPF adds RED + network metrics; optional Beyla spans are separate from Effect traces.
+- On Linux, Pyroscope eBPF adds CPU profiles in Pyroscope.
 
 ## Errors
 

--- a/apps/docs/content/en/how-to/ebpf.md
+++ b/apps/docs/content/en/how-to/ebpf.md
@@ -1,12 +1,13 @@
 # Linux eBPF observability (Beyla)
 
 ## Goal
-Collect eBPF RED + network metrics (and optionally spans) for the smart-address service on Linux.
+Collect eBPF RED + network metrics (and optional spans) plus CPU profiles for the smart-address service on Linux.
 
 ## Prerequisites
 - Linux kernel >= 5.8 with BTF enabled (`/sys/kernel/btf/vmlinux`).
 - Docker running on a Linux host/VM (eBPF is Linux-only).
 - `deploy/compose/obs.yaml`, `deploy/compose/app.yaml`, `deploy/compose/alloy.yaml`.
+- Alloy runs as root with host PID namespace and `/tmp/symb-cache` mounted.
 
 ## Inputs
 - Optional: `SMART_ADDRESS_BEYLA_OTLP_ENDPOINT` to override the OTLP endpoint for Beyla traces (default `lgtm:4317`).
@@ -28,6 +29,7 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 
 ## Output
 - Grafana shows Beyla RED + network metrics under the Prometheus data source.
+- Pyroscope shows CPU profiles for `smart-address` after load.
 - If enabled, Beyla spans appear in Tempo (separate from Effect traces).
 
 ## Errors

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -23,6 +23,22 @@ discovery.relabel "smart_address_logs" {
   }
 }
 
+discovery.relabel "smart_address_pyroscope" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = ".*/.*smart-address.*"
+    action        = "keep"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "service_name"
+  }
+}
+
 loki.source.docker "smart_address" {
   host          = "unix:///var/run/docker.sock"
   targets       = discovery.docker.containers.targets
@@ -137,4 +153,15 @@ otelcol.exporter.otlp "beyla" {
   client {
     endpoint = coalesce(sys.env("SMART_ADDRESS_BEYLA_OTLP_ENDPOINT"), "lgtm:4317")
   }
+}
+
+pyroscope.write "lgtm" {
+  endpoint {
+    url = "http://lgtm:4040"
+  }
+}
+
+pyroscope.ebpf "smart_address" {
+  forward_to = [pyroscope.write.lgtm.receiver]
+  targets    = discovery.relabel.smart_address_pyroscope.output
 }

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -126,3 +126,15 @@ otelcol.exporter.otlp "beyla" {
     endpoint = coalesce(sys.env("SMART_ADDRESS_BEYLA_OTLP_ENDPOINT"), "lgtm:4317")
   }
 }
+
+otelcol.processor.batch "beyla" {
+  output {
+    traces = [otelcol.exporter.otlp.beyla.input]
+  }
+}
+
+otelcol.exporter.otlp "beyla" {
+  client {
+    endpoint = coalesce(sys.env("SMART_ADDRESS_BEYLA_OTLP_ENDPOINT"), "lgtm:4317")
+  }
+}

--- a/deploy/compose/alloy.yaml
+++ b/deploy/compose/alloy.yaml
@@ -9,7 +9,7 @@ services:
     # Root is required for docker.sock access and future eBPF components; run in trusted environments.
     user: "0"
     privileged: true
-    pid: "service:smart-address"
+    pid: "host"
     ports:
       - "12345:12345"
     volumes:
@@ -18,6 +18,7 @@ services:
       # docker.sock grants access to container logs; consider docker group for non-root alternatives.
       - /var/run/docker.sock:/var/run/docker.sock
       - alloy-data:/var/lib/alloy/data
+      - alloy-symb-cache:/tmp/symb-cache
     depends_on:
       - lgtm
       - smart-address
@@ -25,3 +26,4 @@ services:
 
 volumes:
   alloy-data:
+  alloy-symb-cache:

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -1,12 +1,13 @@
 # eBPF runbook (Linux)
 
 ## Goal
-Run Beyla eBPF metrics (and optional traces) for smart-address on Linux using Alloy + LGTM.
+Run Beyla eBPF metrics (and optional traces) plus Pyroscope eBPF profiling for smart-address on Linux using Alloy + LGTM.
 
 ## Prerequisites
 - Linux kernel >= 5.8 with BTF enabled.
 - Docker engine running on the Linux host or VM.
 - This repo with `deploy/compose/obs.yaml`, `deploy/compose/app.yaml`, and `deploy/compose/alloy.yaml`.
+- Alloy runs as root with host PID namespace and `/tmp/symb-cache` mounted (configured in `deploy/compose/alloy.yaml`).
 
 ## Inputs
 - Optional: `SMART_ADDRESS_BEYLA_OTLP_ENDPOINT` to override the OTLP target for Beyla traces (default is `lgtm:4317`).
@@ -29,6 +30,7 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 
 ## Output
 - Grafana shows Beyla RED + network metrics (Prometheus data source).
+- Pyroscope shows CPU profiles for `smart-address` after load.
 - Optional: Beyla spans appear in Tempo when `exports` includes `traces`.
 
 ## Errors


### PR DESCRIPTION
Adds pyroscope.ebpf config + docs for CPU profiling on Linux. Stacked PR 5/9.