### PR TITLE
obs: bpftrace IO scripts

### DIFF
--- a/apps/docs/content/cs/how-to/_meta.json
+++ b/apps/docs/content/cs/how-to/_meta.json
@@ -5,5 +5,6 @@
   "add-provider",
   "legacy-js-integration",
   "ebpf",
+  "ebpf-sqlite-io",
   "proxmox"
 ]

--- a/apps/docs/content/cs/how-to/ebpf-sqlite-io.md
+++ b/apps/docs/content/cs/how-to/ebpf-sqlite-io.md
@@ -1,14 +1,17 @@
 # SQLite I/O latence (bpftrace)
 
 ## Cíl
+
 Zjistit latency čtení/zápisu SQLite a fsync špičky na Linuxu a propojit je s časem requestů.
 
 ## Předpoklady
+
 - Linux host/VM s podporou eBPF.
 - Nainstalovaný `bpftrace` a root oprávnění.
 - smart-address běží v Dockeru.
 
 ## Vstupy
+
 - PID kontejneru smart-address.
 - Volitelný práh latence v milisekundách.
 
@@ -36,13 +39,16 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 ```
 
 ## Výstup
+
 - Řádky v konzoli s latencí `read`, `write`, `fsync`, `fdatasync` v milisekundách.
 - Korelujte čas s request spany v Grafaně.
 
 ## Chyby
+
 - `bpftrace: command not found`: nainstalujte `bpftrace` ve VM.
 - `permission denied`: použijte `sudo` a ověřte podporu eBPF.
 
 ## Viz také
+
 - `/docs/ebpf-sqlite-io.md`
 - `/cs/how-to/ebpf`

--- a/apps/docs/content/cs/how-to/ebpf-sqlite-io.md
+++ b/apps/docs/content/cs/how-to/ebpf-sqlite-io.md
@@ -1,0 +1,48 @@
+# SQLite I/O latence (bpftrace)
+
+## Cíl
+Zjistit latency čtení/zápisu SQLite a fsync špičky na Linuxu a propojit je s časem requestů.
+
+## Předpoklady
+- Linux host/VM s podporou eBPF.
+- Nainstalovaný `bpftrace` a root oprávnění.
+- smart-address běží v Dockeru.
+
+## Vstupy
+- PID kontejneru smart-address.
+- Volitelný práh latence v milisekundách.
+
+Najděte PID kontejneru:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.ID}}" | grep smart-address
+docker inspect --format '{{.State.Pid}}' smart-address
+```
+
+Spusťte latency sondy (příklad s prahem 10 ms):
+
+```bash
+sudo bpftrace deploy/ebpf-tools/io-latency.bt <PID> 10
+```
+
+```bash
+sudo bpftrace deploy/ebpf-tools/fsync-latency.bt <PID> 10
+```
+
+Vygenerujte zátěž:
+
+```bash
+curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/null
+```
+
+## Výstup
+- Řádky v konzoli s latencí `read`, `write`, `fsync`, `fdatasync` v milisekundách.
+- Korelujte čas s request spany v Grafaně.
+
+## Chyby
+- `bpftrace: command not found`: nainstalujte `bpftrace` ve VM.
+- `permission denied`: použijte `sudo` a ověřte podporu eBPF.
+
+## Viz také
+- `/docs/ebpf-sqlite-io.md`
+- `/cs/how-to/ebpf`

--- a/apps/docs/content/cs/how-to/ebpf.md
+++ b/apps/docs/content/cs/how-to/ebpf.md
@@ -40,3 +40,4 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 ## Viz také
 - `/docs/ebpf.md`
 - `/cs/explanation/observability`
+- `/cs/how-to/ebpf-sqlite-io`

--- a/apps/docs/content/cs/how-to/index.md
+++ b/apps/docs/content/cs/how-to/index.md
@@ -9,4 +9,5 @@ Praktické návody zaměřené na konkrétní výsledek. Předpokládají, že u
 - [Přidání dalšího providera](/cs/how-to/add-provider)
 - [Integrace legacy checkoutu (Bootstrap + vanilla JS)](/cs/how-to/legacy-js-integration)
 - [Zapnutí Linux eBPF observability (Beyla)](/cs/how-to/ebpf)
+- [Sledování SQLite I/O latence (bpftrace)](/cs/how-to/ebpf-sqlite-io)
 - [Deploy na Proxmoxu (Docker VM)](/cs/how-to/proxmox)

--- a/apps/docs/content/en/how-to/_meta.json
+++ b/apps/docs/content/en/how-to/_meta.json
@@ -5,5 +5,6 @@
   "add-provider",
   "legacy-js-integration",
   "ebpf",
+  "ebpf-sqlite-io",
   "proxmox"
 ]

--- a/apps/docs/content/en/how-to/ebpf-sqlite-io.md
+++ b/apps/docs/content/en/how-to/ebpf-sqlite-io.md
@@ -1,0 +1,48 @@
+# SQLite I/O latency tracing (bpftrace)
+
+## Goal
+Inspect SQLite read/write and fsync latency spikes on Linux to correlate slow I/O with request windows.
+
+## Prerequisites
+- Linux host/VM with eBPF support.
+- `bpftrace` installed and root privileges.
+- smart-address running in Docker.
+
+## Inputs
+- Target PID of the smart-address container.
+- Optional latency threshold in milliseconds.
+
+Find the container PID:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.ID}}" | grep smart-address
+docker inspect --format '{{.State.Pid}}' smart-address
+```
+
+Run the latency probes (example with 10ms threshold):
+
+```bash
+sudo bpftrace deploy/ebpf-tools/io-latency.bt <PID> 10
+```
+
+```bash
+sudo bpftrace deploy/ebpf-tools/fsync-latency.bt <PID> 10
+```
+
+Generate load:
+
+```bash
+curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/null
+```
+
+## Output
+- Console lines showing `read`, `write`, `fsync`, and `fdatasync` latency in milliseconds.
+- Correlate timestamps with request spans in Grafana.
+
+## Errors
+- `bpftrace: command not found`: install `bpftrace` in the VM.
+- `permission denied`: run with `sudo` and ensure the kernel supports eBPF.
+
+## See also
+- `/docs/ebpf-sqlite-io.md`
+- `/how-to/ebpf`

--- a/apps/docs/content/en/how-to/ebpf-sqlite-io.md
+++ b/apps/docs/content/en/how-to/ebpf-sqlite-io.md
@@ -1,14 +1,17 @@
 # SQLite I/O latency tracing (bpftrace)
 
 ## Goal
+
 Inspect SQLite read/write and fsync latency spikes on Linux to correlate slow I/O with request windows.
 
 ## Prerequisites
+
 - Linux host/VM with eBPF support.
 - `bpftrace` installed and root privileges.
 - smart-address running in Docker.
 
 ## Inputs
+
 - Target PID of the smart-address container.
 - Optional latency threshold in milliseconds.
 
@@ -36,13 +39,16 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 ```
 
 ## Output
+
 - Console lines showing `read`, `write`, `fsync`, and `fdatasync` latency in milliseconds.
 - Correlate timestamps with request spans in Grafana.
 
 ## Errors
+
 - `bpftrace: command not found`: install `bpftrace` in the VM.
 - `permission denied`: run with `sudo` and ensure the kernel supports eBPF.
 
 ## See also
+
 - `/docs/ebpf-sqlite-io.md`
 - `/how-to/ebpf`

--- a/apps/docs/content/en/how-to/ebpf.md
+++ b/apps/docs/content/en/how-to/ebpf.md
@@ -40,3 +40,4 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 ## See also
 - `/docs/ebpf.md`
 - `/explanation/observability`
+- `/how-to/ebpf-sqlite-io`

--- a/apps/docs/content/en/how-to/index.md
+++ b/apps/docs/content/en/how-to/index.md
@@ -9,4 +9,5 @@ Task-focused guides for getting specific outcomes. These assume you already have
 - [Add another provider](/how-to/add-provider)
 - [Integrate legacy checkout (Bootstrap + vanilla JS)](/how-to/legacy-js-integration)
 - [Enable Linux eBPF observability (Beyla)](/how-to/ebpf)
+- [Trace SQLite I/O latency (bpftrace)](/how-to/ebpf-sqlite-io)
 - [Deploy on Proxmox (Docker VM)](/how-to/proxmox)

--- a/deploy/ebpf-tools/fsync-latency.bt
+++ b/deploy/ebpf-tools/fsync-latency.bt
@@ -1,0 +1,37 @@
+#!/usr/bin/env bpftrace
+
+BEGIN
+{
+  $pid = $1;
+  $threshold_ms = $2;
+  if ($threshold_ms == 0) { $threshold_ms = 5; }
+  printf("Tracing fsync latency > %d ms for pid %d... Hit Ctrl-C to stop.\n", $threshold_ms, $pid);
+}
+
+tracepoint:syscalls:sys_enter_fsync /pid == $pid/
+{
+  @start[tid] = nsecs;
+}
+
+tracepoint:syscalls:sys_exit_fsync /@start[tid]/
+{
+  $delta_ms = (nsecs - @start[tid]) / 1000000;
+  if ($delta_ms >= $threshold_ms) {
+    printf("fsync %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
+  }
+  delete(@start[tid]);
+}
+
+tracepoint:syscalls:sys_enter_fdatasync /pid == $pid/
+{
+  @start_fd[tid] = nsecs;
+}
+
+tracepoint:syscalls:sys_exit_fdatasync /@start_fd[tid]/
+{
+  $delta_ms = (nsecs - @start_fd[tid]) / 1000000;
+  if ($delta_ms >= $threshold_ms) {
+    printf("fdatasync %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
+  }
+  delete(@start_fd[tid]);
+}

--- a/deploy/ebpf-tools/io-latency.bt
+++ b/deploy/ebpf-tools/io-latency.bt
@@ -10,28 +10,28 @@ BEGIN
 
 tracepoint:syscalls:sys_enter_read /pid == $pid/
 {
-  @start[tid, "read"] = nsecs;
+  @start_read[tid] = nsecs;
 }
 
-tracepoint:syscalls:sys_exit_read /@start[tid, "read"]/
+tracepoint:syscalls:sys_exit_read /@start_read[tid]/
 {
-  $delta_ms = (nsecs - @start[tid, "read"]) / 1000000;
+  $delta_ms = (nsecs - @start_read[tid]) / 1000000;
   if ($delta_ms >= $threshold_ms) {
     printf("read  %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
   }
-  delete(@start[tid, "read"]);
+  delete(@start_read[tid]);
 }
 
 tracepoint:syscalls:sys_enter_write /pid == $pid/
 {
-  @start[tid, "write"] = nsecs;
+  @start_write[tid] = nsecs;
 }
 
-tracepoint:syscalls:sys_exit_write /@start[tid, "write"]/
+tracepoint:syscalls:sys_exit_write /@start_write[tid]/
 {
-  $delta_ms = (nsecs - @start[tid, "write"]) / 1000000;
+  $delta_ms = (nsecs - @start_write[tid]) / 1000000;
   if ($delta_ms >= $threshold_ms) {
     printf("write %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
   }
-  delete(@start[tid, "write"]);
+  delete(@start_write[tid]);
 }

--- a/deploy/ebpf-tools/io-latency.bt
+++ b/deploy/ebpf-tools/io-latency.bt
@@ -1,0 +1,37 @@
+#!/usr/bin/env bpftrace
+
+BEGIN
+{
+  $pid = $1;
+  $threshold_ms = $2;
+  if ($threshold_ms == 0) { $threshold_ms = 5; }
+  printf("Tracing read/write latency > %d ms for pid %d... Hit Ctrl-C to stop.\n", $threshold_ms, $pid);
+}
+
+tracepoint:syscalls:sys_enter_read /pid == $pid/
+{
+  @start[tid, "read"] = nsecs;
+}
+
+tracepoint:syscalls:sys_exit_read /@start[tid, "read"]/
+{
+  $delta_ms = (nsecs - @start[tid, "read"]) / 1000000;
+  if ($delta_ms >= $threshold_ms) {
+    printf("read  %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
+  }
+  delete(@start[tid, "read"]);
+}
+
+tracepoint:syscalls:sys_enter_write /pid == $pid/
+{
+  @start[tid, "write"] = nsecs;
+}
+
+tracepoint:syscalls:sys_exit_write /@start[tid, "write"]/
+{
+  $delta_ms = (nsecs - @start[tid, "write"]) / 1000000;
+  if ($delta_ms >= $threshold_ms) {
+    printf("write %d ms pid=%d comm=%s ret=%d\n", $delta_ms, pid, comm, args->ret);
+  }
+  delete(@start[tid, "write"]);
+}

--- a/docs/ebpf-sqlite-io.md
+++ b/docs/ebpf-sqlite-io.md
@@ -1,0 +1,47 @@
+# SQLite I/O latency tracing (bpftrace)
+
+## Goal
+Inspect SQLite read/write and fsync latency spikes on Linux to correlate slow I/O with request windows.
+
+## Prerequisites
+- Linux host/VM with eBPF support.
+- `bpftrace` installed and root privileges.
+- smart-address running in Docker.
+
+## Inputs
+- Target PID of the smart-address container.
+- Optional latency threshold in milliseconds.
+
+Find the container PID:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.ID}}" | grep smart-address
+docker inspect --format '{{.State.Pid}}' smart-address
+```
+
+Run the latency probes (examples with 10ms threshold):
+
+```bash
+sudo bpftrace deploy/ebpf-tools/io-latency.bt <PID> 10
+```
+
+```bash
+sudo bpftrace deploy/ebpf-tools/fsync-latency.bt <PID> 10
+```
+
+Generate load:
+
+```bash
+curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/null
+```
+
+## Output
+- Console lines showing `read`, `write`, `fsync`, and `fdatasync` latency in milliseconds.
+- Correlate timestamps with request spans in Grafana.
+
+## Errors
+- `bpftrace: command not found`: install `bpftrace` in the VM.
+- `permission denied`: run with `sudo` and ensure the kernel supports eBPF.
+
+## See also
+- `docs/ebpf.md`

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -41,3 +41,4 @@ curl -fsS "http://localhost:8787/suggest?q=Prague&limit=5&countryCode=CZ" >/dev/
 ## See also
 - `scripts/ebpf-preflight.sh`
 - `deploy/alloy/config.alloy`
+- `docs/ebpf-sqlite-io.md`


### PR DESCRIPTION
Adds bpftrace scripts + runbook for SQLite/file IO latency. Stacked PR 7/9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive how-to guides for measuring SQLite I/O latency and fsync peaks on Linux using bpftrace, available in English and Czech, including objectives, prerequisites, detailed steps, load generation examples, and troubleshooting guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->