### PR TITLE
Clean up test helpers and request-event types

### DIFF
--- a/apps/service-bun/src/request-event.ts
+++ b/apps/service-bun/src/request-event.ts
@@ -61,8 +61,15 @@ export interface ProviderEvent {
   readonly ok: boolean;
 }
 
-interface WideEvent {
-  readonly timestamp: string;
+interface RequestEventPlan {
+  readonly stages: ReadonlyArray<{
+    readonly name?: string | undefined;
+    readonly concurrency?: number | "unbounded" | undefined;
+    readonly providers: readonly string[];
+  }>;
+}
+
+interface RequestEventBase {
   readonly requestId: string;
   readonly traceId?: string | undefined;
   readonly spanId?: string | undefined;
@@ -79,15 +86,16 @@ interface WideEvent {
   readonly normalizedQuery?: AddressQuery | undefined;
   readonly cacheKey?: string | undefined;
   readonly cache?: CacheEventUpdate | undefined;
-  readonly plan?:
-    | {
-        readonly stages: ReadonlyArray<{
-          readonly name?: string | undefined;
-          readonly concurrency?: number | "unbounded" | undefined;
-          readonly providers: readonly string[];
-        }>;
-      }
-    | undefined;
+  readonly plan?: RequestEventPlan | undefined;
+  readonly error?: { readonly message: string } | undefined;
+}
+
+interface WideEvent extends RequestEventBase {
+  readonly timestamp: string;
+  readonly service: string;
+  readonly version?: string | undefined;
+  readonly statusCode: number;
+  readonly durationMs: number;
   readonly providers?: readonly ProviderEvent[] | undefined;
   readonly result?:
     | {
@@ -104,7 +112,6 @@ interface WideEvent {
         readonly resultCount?: number | undefined;
       }
     | undefined;
-  readonly error?: { readonly message: string } | undefined;
   readonly sampling: SamplingDecision;
 }
 
@@ -114,23 +121,11 @@ interface SamplingDecision {
   readonly rate?: number | undefined;
 }
 
-interface RequestEventState {
-  readonly requestId: string;
-  readonly kind: RequestEventKind;
-  readonly source: RequestEventSource;
-  readonly method?: string | undefined;
-  readonly path?: string | undefined;
+interface RequestEventState extends RequestEventBase {
   readonly startedAt: number;
-  readonly strategy?: AddressStrategy | undefined;
-  readonly query?: AddressQuery | undefined;
-  readonly normalizedQuery?: AddressQuery | undefined;
-  readonly cacheKey?: string | undefined;
-  readonly cache?: CacheEventUpdate | undefined;
-  readonly plan?: WideEvent["plan"] | undefined;
   readonly providers: ProviderEvent[];
   readonly result?: WideEvent["result"] | undefined;
   readonly accept?: WideEvent["accept"] | undefined;
-  readonly error?: { readonly message: string } | undefined;
   readonly forceSample?: boolean | undefined;
   readonly flushed?: boolean | undefined;
 }

--- a/apps/service-bun/test/http.test.ts
+++ b/apps/service-bun/test/http.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "@effect-native/bun-test";
 import {
   fromWeb,
   type HttpServerRequest,
 } from "@effect/platform/HttpServerRequest";
 import type { HttpServerResponse } from "@effect/platform/HttpServerResponse";
-import { describe, expect, it } from "@effect-native/bun-test";
 import { Effect, Ref } from "effect";
 import {
   type RecordedSpan,

--- a/apps/service-bun/test/http.test.ts
+++ b/apps/service-bun/test/http.test.ts
@@ -6,6 +6,10 @@ import type { HttpServerResponse } from "@effect/platform/HttpServerResponse";
 import { describe, expect, it } from "@effect-native/bun-test";
 import { Effect, Ref } from "effect";
 import {
+  type RecordedSpan,
+  makeTestTracer,
+} from "../../../test-utils/test-tracer";
+import {
   handleAcceptPost,
   handleMetricsGet,
   handleSuggestGet,
@@ -19,10 +23,6 @@ import {
   makeSuggestPostRequest,
   parseJsonResponse,
 } from "./http-helpers";
-import {
-  type RecordedSpan,
-  makeTestTracer,
-} from "../../../test-utils/test-tracer";
 
 const sampleResult = {
   suggestions: [

--- a/apps/service-bun/test/http.test.ts
+++ b/apps/service-bun/test/http.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "@effect-native/bun-test";
 import {
   fromWeb,
   type HttpServerRequest,
 } from "@effect/platform/HttpServerRequest";
 import type { HttpServerResponse } from "@effect/platform/HttpServerResponse";
+import { describe, expect, it } from "@effect-native/bun-test";
 import { Effect, Ref } from "effect";
 import {
-  type RecordedSpan,
   makeTestTracer,
+  type RecordedSpan,
 } from "../../../test-utils/test-tracer";
 import {
   handleAcceptPost,

--- a/apps/service-bun/test/http.test.ts
+++ b/apps/service-bun/test/http.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@effect/platform/HttpServerRequest";
 import type { HttpServerResponse } from "@effect/platform/HttpServerResponse";
 import { describe, expect, it } from "@effect-native/bun-test";
-import { Effect, Ref, Tracer } from "effect";
+import { Effect, Ref } from "effect";
 import {
   handleAcceptPost,
   handleMetricsGet,
@@ -19,46 +19,10 @@ import {
   makeSuggestPostRequest,
   parseJsonResponse,
 } from "./http-helpers";
-
-interface RecordedSpan {
-  name: string;
-  attributes: Map<string, unknown>;
-}
-
-const makeTestTracer = (spans: RecordedSpan[]) => {
-  let counter = 0;
-  return Tracer.make({
-    span: (name, parent, context, links, startTime, kind) => {
-      const attributes = new Map<string, unknown>();
-      spans.push({ name, attributes });
-      let status: Tracer.SpanStatus = { _tag: "Started", startTime };
-      const span: Tracer.Span = {
-        _tag: "Span",
-        name,
-        spanId: `span-${counter++}`,
-        traceId: "trace-1",
-        parent,
-        context,
-        status,
-        attributes,
-        links,
-        sampled: true,
-        kind,
-        end: (endTime, exit) => {
-          status = { _tag: "Ended", startTime, endTime, exit };
-          span.status = status;
-        },
-        attribute: (key, value) => {
-          attributes.set(key, value);
-        },
-        event: () => undefined,
-        addLinks: () => undefined,
-      };
-      return span;
-    },
-    context: (f) => f(),
-  });
-};
+import {
+  type RecordedSpan,
+  makeTestTracer,
+} from "../../../test-utils/test-tracer";
 
 const sampleResult = {
   suggestions: [

--- a/knip.json
+++ b/knip.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://unpkg.com/knip@5.79.0/schema.json",
   "ignoreDependencies": ["@biomejs/biome"],
+  "ignoreFiles": ["test-utils/**"],
   "workspaces": {
     "apps/docs": {
       "entry": ["rspress.config.ts"],
       "ignoreDependencies": ["@smart-address/sdk"]
     },
     "apps/landing": {
-      "entry": ["src/router.tsx"],
-      "ignoreBinaries": ["eslint"]
+      "entry": ["src/router.tsx"]
     },
     "packages/core": {
       "entry": ["src/address.ts", "src/schema.ts"]

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5.79.0/schema.json",
-  "ignoreDependencies": ["@biomejs/biome"],
+  "ignoreDependencies": ["@biomejs/biome", "effect"],
   "ignoreFiles": ["test-utils/**"],
   "workspaces": {
     "apps/docs": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.10",
     "@effect/language-service": "catalog:tooling",
+    "effect": "catalog:prod",
     "lefthook": "^2.0.13",
     "jscpd": "^4.0.5",
     "knip": "^5.79.0",

--- a/packages/core/test/address.test.ts
+++ b/packages/core/test/address.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "@effect-native/bun-test";
 import { Effect } from "effect";
 import {
-  makeTestTracer,
-  type RecordedSpan,
-} from "../../../test-utils/test-tracer";
-import {
   type AddressProviderPlan,
   makeAddressProvider,
   makeAddressSuggestionService,

--- a/packages/core/test/address.test.ts
+++ b/packages/core/test/address.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "@effect-native/bun-test";
 import { Effect } from "effect";
 import {
+  makeTestTracer,
+  type RecordedSpan,
+} from "../../../test-utils/test-tracer";
+import {
   type AddressProviderPlan,
   makeAddressProvider,
   makeAddressSuggestionService,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@effect/language-service':
         specifier: catalog:tooling
         version: 0.62.5
+      effect:
+        specifier: catalog:prod
+        version: 3.19.13
       jscpd:
         specifier: ^4.0.5
         version: 4.0.5

--- a/test-utils/test-tracer.ts
+++ b/test-utils/test-tracer.ts
@@ -1,0 +1,41 @@
+import { Option, Tracer } from "effect";
+
+export interface RecordedSpan {
+  name: string;
+  attributes: Map<string, unknown>;
+  traceId: string;
+}
+
+export const makeTestTracer = (spans: RecordedSpan[]) => {
+  let counter = 0;
+  return Tracer.make({
+    span: (name, parent, context, links, startTime, kind) => {
+      const attributes = new Map<string, unknown>();
+      const traceId = Option.isSome(parent) ? parent.value.traceId : "trace-1";
+      const span: Tracer.Span = {
+        _tag: "Span",
+        name,
+        spanId: `span-${counter++}`,
+        traceId,
+        parent,
+        context,
+        status: { _tag: "Started", startTime },
+        attributes,
+        links,
+        sampled: true,
+        kind,
+        end: (endTime, exit) => {
+          span.status = { _tag: "Ended", startTime, endTime, exit };
+        },
+        attribute: (key, value) => {
+          attributes.set(key, value);
+        },
+        event: () => undefined,
+        addLinks: () => undefined,
+      };
+      spans.push({ name, attributes, traceId });
+      return span;
+    },
+    context: (f) => f(),
+  });
+};


### PR DESCRIPTION
## Summary
- refactor request-event state shape to remove duplicated plan/base fields
- extract a shared test tracer helper for HTTP handler tests
- reduce repeated config setup in request-event tests
- add root dev dependency for Effect test helper and adjust knip ignores

## Testing
- pnpm check:quality
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganised internal request event data structure for improved consistency and maintainability.

* **Tests**
  * Enhanced test infrastructure with new tracing utilities and simplified test configuration setup.

* **Chores**
  * Updated build configuration and added development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->